### PR TITLE
Update Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It provides a Python and command-line interface to the [FluidSynth](http://www.f
 First, FluidSynth has a CLI which is not so straightforward to use. The goal was to make it easy to use as possible by making some parameters implicit.
 
 ```
-fluidsynth -ni sound_font.sf2 input.mid -F output.wav -r 44100
+fluidsynth -ni -F output.wav -r 44100 sound_font.sf2 input.mid
 ```
 
 vs.

--- a/midi2audio.py
+++ b/midi2audio.py
@@ -37,29 +37,35 @@ __all__ = ['FluidSynth']
 DEFAULT_SOUND_FONT = '~/.fluidsynth/default_sound_font.sf2'
 DEFAULT_SAMPLE_RATE = 44100
 
+
 class FluidSynth():
     def __init__(self, sound_font=DEFAULT_SOUND_FONT, sample_rate=DEFAULT_SAMPLE_RATE):
         self.sample_rate = sample_rate
         self.sound_font = os.path.expanduser(sound_font)
 
     def midi_to_audio(self, midi_file, audio_file):
-        subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file, '-F', audio_file, '-r', str(self.sample_rate)])
+        subprocess.call(['fluidsynth', '-ni', '-F', audio_file, '-r', str(self.sample_rate),
+                         self.sound_font, midi_file])
 
     def play_midi(self, midi_file):
-        subprocess.call(['fluidsynth', '-i', self.sound_font, midi_file, '-r', str(self.sample_rate)])
+        subprocess.call(['fluidsynth', '-i', self.sound_font,
+                         midi_file, '-r', str(self.sample_rate)])
+
 
 def parse_args(allow_synth=True):
-    parser = argparse.ArgumentParser(description='Convert MIDI to audio via FluidSynth')
+    parser = argparse.ArgumentParser(
+        description='Convert MIDI to audio via FluidSynth')
     parser.add_argument('midi_file', metavar='MIDI', type=str)
     if allow_synth:
         parser.add_argument('audio_file', metavar='AUDIO', type=str, nargs='?')
     parser.add_argument('-s', '--sound-font', type=str,
-        default=DEFAULT_SOUND_FONT,
-        help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
+                        default=DEFAULT_SOUND_FONT,
+                        help='path to a SF2 sound font (default: {})'.format(DEFAULT_SOUND_FONT))
     parser.add_argument('-r', '--sample-rate', type=int, nargs='?',
-        default=DEFAULT_SAMPLE_RATE,
-        help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
+                        default=DEFAULT_SAMPLE_RATE,
+                        help='sample rate in Hz (default: {})'.format(DEFAULT_SAMPLE_RATE))
     return parser.parse_args()
+
 
 def main(allow_synth=True):
     args = parse_args(allow_synth)
@@ -69,11 +75,13 @@ def main(allow_synth=True):
     else:
         fs.play_midi(args.midi_file)
 
+
 def main_play():
     """
     A method for the `midiplay` entry point. It omits the audio file from args.
     """
     main(allow_synth=False)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Usage:
  fluidsynth [options] [soundfonts] [midifiles]

If we use the old one，we will see:

Parameter '-F' not a SoundFont or MIDI file or error occurred identifying it.
Parameter 'output.wav' not a SoundFont or MIDI file or error occurred identifying it.
Parameter '-r' not a SoundFont or MIDI file or error occurred identifying it.
Parameter '44100' not a SoundFont or MIDI file or error occurred identifying it.

Now, [options] are on the front
Use "fluidsynth -ni -F output.wav -r 44100 sound_font.sf2 input.mid"