### PR TITLE
Added no_log attribute

### DIFF
--- a/midi2audio.py
+++ b/midi2audio.py
@@ -44,12 +44,9 @@ class FluidSynth():
         self.sound_font = os.path.expanduser(sound_font)
 
     def midi_to_audio(self, midi_file, audio_file, no_log=True):
-        if no_log:
-            subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file,
-                             '-F', audio_file, '-r', str(self.sample_rate)], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
-        else:
-            subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file,
-                             '-F', audio_file, '-r', str(self.sample_rate)])
+        stdout = subprocess.DEVNULL if no_log else None
+        stderr = subprocess.DEVNULL if no_log else None
+        subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file, '-F', audio_file, '-r', str(self.sample_rate)], stderr=stderr, stdout=stdout)
 
     def play_midi(self, midi_file):
         subprocess.call(['fluidsynth', '-i', self.sound_font,
@@ -57,8 +54,7 @@ class FluidSynth():
 
 
 def parse_args(allow_synth=True):
-    parser = argparse.ArgumentParser(
-        description='Convert MIDI to audio via FluidSynth')
+    parser = argparse.ArgumentParser(description='Convert MIDI to audio via FluidSynth')
     parser.add_argument('midi_file', metavar='MIDI', type=str)
     if allow_synth:
         parser.add_argument('audio_file', metavar='AUDIO', type=str, nargs='?')

--- a/midi2audio.py
+++ b/midi2audio.py
@@ -37,7 +37,6 @@ __all__ = ['FluidSynth']
 DEFAULT_SOUND_FONT = '~/.fluidsynth/default_sound_font.sf2'
 DEFAULT_SAMPLE_RATE = 44100
 
-
 class FluidSynth():
     def __init__(self, sound_font=DEFAULT_SOUND_FONT, sample_rate=DEFAULT_SAMPLE_RATE):
         self.sample_rate = sample_rate
@@ -49,8 +48,7 @@ class FluidSynth():
         subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file, '-F', audio_file, '-r', str(self.sample_rate)], stderr=stderr, stdout=stdout)
 
     def play_midi(self, midi_file):
-        subprocess.call(['fluidsynth', '-i', self.sound_font,
-                        midi_file, '-r', str(self.sample_rate)])
+        subprocess.call(['fluidsynth', '-i', self.sound_font, midi_file, '-r', str(self.sample_rate)])
 
 
 def parse_args(allow_synth=True):

--- a/midi2audio.py
+++ b/midi2audio.py
@@ -37,29 +37,39 @@ __all__ = ['FluidSynth']
 DEFAULT_SOUND_FONT = '~/.fluidsynth/default_sound_font.sf2'
 DEFAULT_SAMPLE_RATE = 44100
 
+
 class FluidSynth():
     def __init__(self, sound_font=DEFAULT_SOUND_FONT, sample_rate=DEFAULT_SAMPLE_RATE):
         self.sample_rate = sample_rate
         self.sound_font = os.path.expanduser(sound_font)
 
-    def midi_to_audio(self, midi_file, audio_file):
-        subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file, '-F', audio_file, '-r', str(self.sample_rate)])
+    def midi_to_audio(self, midi_file, audio_file, no_log=True):
+        if no_log:
+            subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file,
+                             '-F', audio_file, '-r', str(self.sample_rate)], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+        else:
+            subprocess.call(['fluidsynth', '-ni', self.sound_font, midi_file,
+                             '-F', audio_file, '-r', str(self.sample_rate)])
 
     def play_midi(self, midi_file):
-        subprocess.call(['fluidsynth', '-i', self.sound_font, midi_file, '-r', str(self.sample_rate)])
+        subprocess.call(['fluidsynth', '-i', self.sound_font,
+                        midi_file, '-r', str(self.sample_rate)])
+
 
 def parse_args(allow_synth=True):
-    parser = argparse.ArgumentParser(description='Convert MIDI to audio via FluidSynth')
+    parser = argparse.ArgumentParser(
+        description='Convert MIDI to audio via FluidSynth')
     parser.add_argument('midi_file', metavar='MIDI', type=str)
     if allow_synth:
         parser.add_argument('audio_file', metavar='AUDIO', type=str, nargs='?')
     parser.add_argument('-s', '--sound-font', type=str,
-        default=DEFAULT_SOUND_FONT,
-        help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
+                        default=DEFAULT_SOUND_FONT,
+                        help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
     parser.add_argument('-r', '--sample-rate', type=int, nargs='?',
-        default=DEFAULT_SAMPLE_RATE,
-        help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
+                        default=DEFAULT_SAMPLE_RATE,
+                        help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
     return parser.parse_args()
+
 
 def main(allow_synth=True):
     args = parse_args(allow_synth)
@@ -69,11 +79,13 @@ def main(allow_synth=True):
     else:
         fs.play_midi(args.midi_file)
 
+
 def main_play():
     """
     A method for the `midiplay` entry point. It omits the audio file from args.
     """
     main(allow_synth=False)
+
 
 if __name__ == '__main__':
     main()

--- a/midi2audio.py
+++ b/midi2audio.py
@@ -50,18 +50,17 @@ class FluidSynth():
     def play_midi(self, midi_file):
         subprocess.call(['fluidsynth', '-i', self.sound_font, midi_file, '-r', str(self.sample_rate)])
 
-
 def parse_args(allow_synth=True):
     parser = argparse.ArgumentParser(description='Convert MIDI to audio via FluidSynth')
     parser.add_argument('midi_file', metavar='MIDI', type=str)
     if allow_synth:
         parser.add_argument('audio_file', metavar='AUDIO', type=str, nargs='?')
-    parser.add_argument('-s', '--sound-font', type=str, 
-                        default=DEFAULT_SOUND_FONT,
-                        help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
-    parser.add_argument('-r', '--sample-rate', type=int, nargs='?', 
-                        default=DEFAULT_SAMPLE_RATE,
-                        help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
+    parser.add_argument('-s', '--sound-font', type=str,
+        default=DEFAULT_SOUND_FONT,
+        help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
+    parser.add_argument('-r', '--sample-rate', type=int, nargs='?',
+        default=DEFAULT_SAMPLE_RATE,
+        help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
     return parser.parse_args()
 
 def main(allow_synth=True):

--- a/midi2audio.py
+++ b/midi2audio.py
@@ -56,11 +56,9 @@ def parse_args(allow_synth=True):
     parser.add_argument('midi_file', metavar='MIDI', type=str)
     if allow_synth:
         parser.add_argument('audio_file', metavar='AUDIO', type=str, nargs='?')
-    parser.add_argument('-s', '--sound-font', type=str,
-                        default=DEFAULT_SOUND_FONT,
+    parser.add_argument('-s', '--sound-font', type=str, default=DEFAULT_SOUND_FONT,
                         help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
-    parser.add_argument('-r', '--sample-rate', type=int, nargs='?',
-                        default=DEFAULT_SAMPLE_RATE,
+    parser.add_argument('-r', '--sample-rate', type=int, nargs='?', default=DEFAULT_SAMPLE_RATE,
                         help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
     return parser.parse_args()
 
@@ -73,13 +71,11 @@ def main(allow_synth=True):
     else:
         fs.play_midi(args.midi_file)
 
-
 def main_play():
     """
     A method for the `midiplay` entry point. It omits the audio file from args.
     """
     main(allow_synth=False)
-
 
 if __name__ == '__main__':
     main()

--- a/midi2audio.py
+++ b/midi2audio.py
@@ -56,12 +56,13 @@ def parse_args(allow_synth=True):
     parser.add_argument('midi_file', metavar='MIDI', type=str)
     if allow_synth:
         parser.add_argument('audio_file', metavar='AUDIO', type=str, nargs='?')
-    parser.add_argument('-s', '--sound-font', type=str, default=DEFAULT_SOUND_FONT,
+    parser.add_argument('-s', '--sound-font', type=str, 
+                        default=DEFAULT_SOUND_FONT,
                         help='path to a SF2 sound font (default: %s)' % DEFAULT_SOUND_FONT)
-    parser.add_argument('-r', '--sample-rate', type=int, nargs='?', default=DEFAULT_SAMPLE_RATE,
+    parser.add_argument('-r', '--sample-rate', type=int, nargs='?', 
+                        default=DEFAULT_SAMPLE_RATE,
                         help='sample rate in Hz (default: %s)' % DEFAULT_SAMPLE_RATE)
     return parser.parse_args()
-
 
 def main(allow_synth=True):
     args = parse_args(allow_synth)


### PR DESCRIPTION
Hello everyone! I have added no_log attribute to the midi_to_audio function that allows to suppress logs when running the function in the command line. It might be helpful if you intend to process MIDI files in bulk - you won't get thousands of log outputs in your terminal.